### PR TITLE
removed margin on html

### DIFF
--- a/solarized-light.css
+++ b/solarized-light.css
@@ -176,7 +176,6 @@ h6 {
 html {
   background-color: #eee8d5;
   color: #657b83;
-  margin: 1em;
 }
 body {
   background-color: #fdf6e3;


### PR DESCRIPTION
removed margin: 1em on the html element. Maybe this didnt cause an issue on the earlier version of calibre but as of now there is overflow of the book text because of the margin on html.